### PR TITLE
Allow user to define his parser class

### DIFF
--- a/DependencyInjection/MarkdownExtension.php
+++ b/DependencyInjection/MarkdownExtension.php
@@ -13,6 +13,11 @@ class MarkdownExtension extends Extension
     {
         $loader = new XmlFileLoader($container, __DIR__.'/../Resources/config');
         $loader->load('parser.xml');
+        
+        if(isset($config['class']))
+        {
+            $container->setParameter('markdown.parser.class', $config['class']);
+        }
     }
 
     public function helperLoad($config, ContainerBuilder $container)

--- a/README.markdown
+++ b/README.markdown
@@ -14,6 +14,11 @@ Optionnally enable the twig markdown filter :
     twig.config: ~          # Enable Twig
     markdown.twig: ~        # Enable the markdown filter
 
+You can also define your own Parser class :
+
+    markdown.parser:
+        class: Bundle\HelloBundle\MarkdownParser
+
 ## USAGE
 
     // Use the service


### PR DESCRIPTION
I update your bundle to add geshi support on my blog

My Config:

```
[yml]
markdown.parser:
    class: "Bundle\BlogBundle\MarkdownParser"
```

My parser:

```
[php]
<?php

namespace Bundle\BlogBundle;

use Bundle\MarkdownBundle\Parser\Preset\Max as BaseParser;

require_once dirname(dirname(__DIR__)).'/vendor/geshi/geshi.php';

class MarkdownParser extends BaseParser
{

  protected function _doCodeBlocks_callback($matches)
  {
    $codeblock = $matches[1];

    $codeblock = $this->outdent($codeblock);

    # trim leading newlines and trailing newlines
    $codeblock = preg_replace('/\A\n+|\n+\z/', '', $codeblock);

    // if it start w/ a language tag, use GeSHi to convert the code
    if (preg_match('/^\[(\w+)\]\s*/', $codeblock, $match))
    {
      $codeblock = str_replace("[${match[1]}]\n", '', $codeblock);
      $geshi = new \GeSHi($codeblock, $match[1]);
      $geshi->enable_classes();
      $codeblock = $geshi->parse_code();
    }
    else
    {
      $codeblock = htmlspecialchars($codeblock, ENT_NOQUOTES);
      $codeblock = "<pre><code>$codeblock\n</code></pre>";
    }

    return "\n\n" . $this->hashBlock($codeblock) . "\n\n";
  }

}
```
