### PR TITLE
vendor-prefixed the helper and made it publicly available

### DIFF
--- a/Resources/config/helper.xml
+++ b/Resources/config/helper.xml
@@ -6,13 +6,13 @@
 
   <parameters>
 
-    <parameter key="templating.helper.markdown.class">Knp\Bundle\MarkdownBundle\Helper\MarkdownHelper</parameter>
+    <parameter key="knp_markdown.helper.markdown.class">Knp\Bundle\MarkdownBundle\Helper\MarkdownHelper</parameter>
 
   </parameters>
 
   <services>
 
-    <service id="templating.helper.markdown" class="%templating.helper.markdown.class%" public="false">
+    <service id="knp_markdown.helper.markdown" class="%knp_markdown.helper.markdown.class%">
       <tag name="templating.helper" alias="markdown" />
       <argument type="service" id="markdown.parser" />
     </service>

--- a/Resources/config/twig.xml
+++ b/Resources/config/twig.xml
@@ -6,7 +6,7 @@
 
     <services>
         <service id="twig.extension.exercise.twig" class="Knp\Bundle\MarkdownBundle\Twig\Extension\MarkdownTwigExtension" public="false">
-            <argument type="service" id="templating.helper.markdown" />
+            <argument type="service" id="knp_markdown.helper.markdown" />
             <tag name="twig.extension" />
         </service>
     </services>


### PR DESCRIPTION
This allows using it outside of Twig templates.
