### PR TITLE
Added an upper bound on the composer constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "symfony/framework-bundle": ">=2.0,<2.2-dev"
     },
 
-    "require": {
+    "suggest": {
         "symfony/twig-bundle": "to use the Twig markdown filter"
     },
 


### PR DESCRIPTION
This adds an upper bound on the constraint to avoid breaking things later (tagging a release with the previous constraint requires knowing the future) and adds a suggestion on TwigBundle
