### PR TITLE
Fix no_html feature

### DIFF
--- a/Parser/Preset/Light.php
+++ b/Parser/Preset/Light.php
@@ -27,7 +27,8 @@ class Light extends MarkdownParser
         'code_block' => false,
         'auto_link' => true,
         'auto_mailto' => false,
-        'entities' => false
+        'entities' => false,
+        'no_html' => false,
     );
 
 }

--- a/Parser/Preset/Medium.php
+++ b/Parser/Preset/Medium.php
@@ -27,7 +27,8 @@ class Medium extends MarkdownParser
         'code_block' => true,
         'auto_link' => true,
         'auto_mailto' => false,
-        'entities' => false
+        'entities' => false,
+        'no_html' => false,
     );
 
 }


### PR DESCRIPTION
Light & Medium parsers should overwrite all the keys in protected $features array to avoid notice: Undefined index: no_html.
