### PR TITLE
Reverted the interface renaming done in #50

### DIFF
--- a/MarkdownParserInterface.php
+++ b/MarkdownParserInterface.php
@@ -11,5 +11,5 @@ interface MarkdownParserInterface
      *
      * @return string rendered html
      */
-    function transform($text);
+    function transformMarkdown($text);
 }

--- a/Parser/SundownParser.php
+++ b/Parser/SundownParser.php
@@ -23,7 +23,7 @@ class SundownParser implements MarkdownParserInterface
     /**
      * {@inheritdoc}
      */
-    public function transform($text)
+    public function transformMarkdown($text)
     {
         return $this->parser->render($text);
     }


### PR DESCRIPTION
All code in the bundle is still relying on the transformMarkdown method in parsers, not on the transform method.
Normal parsers are still working because they still have the method, and PHP does not have strict type checking for typehints.
However, the SundownParser is still broken in 1.3.1. #51 renamed the method to avoid a fatal error for the interface, but then the method used by the bundle became missing.

Note that unit tests for the MarkdownHelper could have catched such mistake.
