### PR TITLE
Updated php-markdown - from 1.4.0 to 1.4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php":                      ">=5.3.9",
         "symfony/framework-bundle": "~2.1",
-        "michelf/php-markdown":     "1.4.0"
+        "michelf/php-markdown":     "1.4.1"
     },
 
     "suggest": {


### PR DESCRIPTION
https://github.com/michelf/php-markdown/tree/1.4.1#version-history
### PHP Markdown Lib 1.4.1 (4 May 2014)
- The HTML block parser will now treat `<figure>` as a block-level element (as it should) and no longer wrap it in `<p>` or parse it's content with the as Markdown syntax (although with Extra you can use markdown="1" if you wish to use the Markdown syntax inside it).
- The content of `<style>` elements will now be left alone, its content won't be interpreted as Markdown.
- Corrected an bug where some inline links with spaces in them would not work even when surounded with angle brackets:

`[link](<s p a c e s>)`
- Fixed an issue where email addresses with quotes in them would not always have the quotes escaped in the link attribute, causing broken links (and invalid HTML).
- Fixed the case were a link definition following a footnote definition would be swallowed by the footnote unless it was separated by a blank line.
