### PR TITLE
Fix the branch alias for master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 
     "extra": {
         "branch-alias": {
-            "dev-master": "1.3.x-dev"
+            "dev-master": "1.4.x-dev"
         }
     },
 


### PR DESCRIPTION
The latest release was number 1.4, so the master branch is not 1.3.x anymore