### PR TITLE
Switch the Twig integration to use non-deprecated APIs

### DIFF
--- a/Twig/Extension/MarkdownTwigExtension.php
+++ b/Twig/Extension/MarkdownTwigExtension.php
@@ -16,7 +16,7 @@ class MarkdownTwigExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            return new \Twig_SimpleFilter('markdown', array($this, 'markdown'), array('is_safe' => array('html'))),
+            new \Twig_SimpleFilter('markdown', array($this, 'markdown'), array('is_safe' => array('html'))),
         );
     }
 

--- a/Twig/Extension/MarkdownTwigExtension.php
+++ b/Twig/Extension/MarkdownTwigExtension.php
@@ -8,7 +8,7 @@ class MarkdownTwigExtension extends \Twig_Extension
 {
     protected $helper;
 
-    function __construct(MarkdownHelper $helper)
+    public function __construct(MarkdownHelper $helper)
     {
         $this->helper = $helper;
     }
@@ -16,7 +16,7 @@ class MarkdownTwigExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            'markdown' => new \Twig_Filter_Method($this, 'markdown', array('is_safe' => array('html'))),
+            return new \Twig_SimpleFilter('markdown', array($this, 'markdown'), array('is_safe' => array('html'))),
         );
     }
 


### PR DESCRIPTION
This makes the bundle compatible with Twig 2.0 and avoids the deprecation warning in 1.21+.

This requires Twig 1.12+, but Symfony already has this min requirement on Twig since 2.3.0
