### PR TITLE
fix the `no_html` option

### DIFF
--- a/Parser/MarkdownParser.php
+++ b/Parser/MarkdownParser.php
@@ -105,7 +105,7 @@ class MarkdownParser extends MarkdownExtra implements MarkdownParserInterface
             $this->no_entities = true;
         }
         if (true === $this->features['no_html']) {
-            $this->no_html = true;
+            $this->no_markup = true;
         }
     }
 


### PR DESCRIPTION
#45 broke the feature of the underlying library to escape HTML tags since the property is named differently.