### PR TITLE
Allow newer versions of php-markdown

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php":                      ">=5.3.9",
         "symfony/framework-bundle": "~2.1",
-        "michelf/php-markdown":     "1.4.*"
+        "michelf/php-markdown":     "~1.4"
     },
     "require-dev": {
         "phpunit/phpunit":          "~4.5"


### PR DESCRIPTION
The latest release of the library is 1.5.0, but the previous constraint was not allowing it.