### PR TITLE
Improve the Travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: php
 
+sudo: false
+
+cache:
+    directories:
+        - $HOME/.composer/cache/files
+
 php:
     - 5.3
     - 5.4
@@ -9,12 +15,19 @@ php:
     - hhvm
 
 matrix:
-    allow_failures:
-        - php: 7.0
-        - php: hhvm
+    include:
+        # Test against lowest bounds of dependencies to ensure they are right
+        - php: 5.6
+          env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
+        # Test against dev versions of dependencies
+        - php: 5.6
+          env: deps=dev
 
-before_script:
-    - composer install
+before_install:
+    - if [ "$deps" = 'dev' ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
+
+install:
+    - composer update $COMPOSER_FLAGS
 
 script: phpunit --coverage-text
 

--- a/Tests/FeatureTest.php
+++ b/Tests/FeatureTest.php
@@ -299,6 +299,19 @@ EOF;
 8. Parish
 EOF;
 
+        // Since version 1.5.0, the ordered lists support this new feature.
+        if (property_exists($parser, 'enhanced_ordered_list')) {
+
+            $html = <<<EOF
+<ol start="3">
+<li>Bird</li>
+<li>McHale</li>
+<li>Parish</li>
+</ol>
+
+EOF;
+        }
+
         $this->assertSame($html, $parser->transform($text));
     }
 


### PR DESCRIPTION
- use the container-based infrastructure
- persist the composer download cache between builds
- disallow failures on PHP 7 and HHVM
- add testing against lowest bounds of dependencies
- add testing against dev version of dependencies

This also fixes testing against php-markdown 1.5 as the master branch gets installed for dev builds currently because it is aliased as 1.4.x-dev wrongly. This is a good idea anyway because of #77 