### PR TITLE
Fix bad argument on MardownHelper service

### DIFF
--- a/Resources/config/helper.xml
+++ b/Resources/config/helper.xml
@@ -9,7 +9,7 @@
 
     <services>
         <service id="templating.helper.markdown" class="%templating.helper.markdown.class%">
-            <argument type="service" id="markdown.parser" />
+            <argument type="service" id="markdown.parser.parser_manager" />
             <tag name="templating.helper" alias="markdown" />
         </service>
     </services>


### PR DESCRIPTION
Fixes #84.

`MardownHelper::__construct` argument was changed on #81 but the argument change is missing on the service definition.