### PR TITLE
fixed returning a doctype declaration when the markdownText is null. …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ phpunit.xml
 vendor/*
 composer.lock
 Tests/fixtures/app/cache
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ phpunit.xml
 vendor/*
 composer.lock
 Tests/fixtures/app/cache
+.idea

--- a/Parser/ParserManager.php
+++ b/Parser/ParserManager.php
@@ -32,6 +32,10 @@ class ParserManager
      */
     public function transform($markdownText, $parserName = null)
     {
+        if (is_null($markdownText)) {
+            return '';
+        }
+
         if (null === $parserName) {
             $parserName = 'default';
         }


### PR DESCRIPTION
…It should return an empty string when null is passed in. At least: that seems the sensible thing to do.
