### PR TITLE
Prepare bundle to amazing Symfony 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ php:
 
 matrix:
     include:
+        # Use precise for PHP 5.3
+        - php: 5.3
+          dist: precise
         # Test against lowest bounds of dependencies to ensure they are right
         - php: 5.6
           env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ php:
     - 5.5
     - 5.6
     - 7.0
+    - 7.1
     - hhvm
 
 matrix:
@@ -22,8 +23,12 @@ matrix:
         # Test against dev versions of dependencies
         - php: 5.6
           env: deps=dev
+        # test the latest release (including beta releases)
+        - php: 7.1
+          env: deps=beta
 
 before_install:
+    - if [ "$deps" = 'beta' ]; then perl -pi -e 's/^}$/,"minimum-stability":"beta"}/' composer.json; fi;
     - if [ "$deps" = 'dev' ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,20 +7,14 @@ cache:
         - $HOME/.composer/cache/files
 
 php:
-    - 5.3
-    - 5.4
     - 5.5
     - 5.6
     - 7.0
     - 7.1
-    - hhvm
 
 matrix:
     fast_finish: true
     include:
-        # Use precise for PHP 5.3
-        - php: 5.3
-          dist: precise
         # Test against lowest bounds of dependencies to ensure they are right
         - php: 5.6
           env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
@@ -30,10 +24,6 @@ matrix:
         # test the latest release (including beta releases)
         - php: 7.1
           env: deps=beta
-    allow_failures:
-        - php: 5.3
-          dist: trusty # Only fail if dist is trustry
-        - php: hhvm
 
 before_install:
     - if [ "$deps" = 'beta' ]; then perl -pi -e 's/^}$/,"minimum-stability":"beta"}/' composer.json; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ php:
     - hhvm
 
 matrix:
+    fast_finish: true
     include:
         # Use precise for PHP 5.3
         - php: 5.3
@@ -29,6 +30,10 @@ matrix:
         # test the latest release (including beta releases)
         - php: 7.1
           env: deps=beta
+    allow_failures:
+        - php: 5.3
+          dist: trusty # Only fail if dist is trustry
+        - php: hhvm
 
 before_install:
     - if [ "$deps" = 'beta' ]; then perl -pi -e 's/^}$/,"minimum-stability":"beta"}/' composer.json; fi;

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
 
     "require": {
         "php":                      ">=5.3.9",
-        "symfony/framework-bundle": "~2.3|~3.0",
-        "symfony/dependency-injection": "~2.3|~3.0",
+        "symfony/framework-bundle": "~2.3|~3.0|^4.0",
+        "symfony/dependency-injection": "~2.3|~3.0|^4.0",
         "michelf/php-markdown":     "~1.4"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
     ],
 
     "require": {
-        "php":                      ">=5.3.9",
-        "symfony/framework-bundle": "~2.3|~3.0|^4.0",
-        "symfony/dependency-injection": "~2.3|~3.0|^4.0",
-        "symfony/templating": "~2.3|~3.0|^4.0",
+        "php":                      ">=5.5.9",
+        "symfony/framework-bundle": "~2.8|~3.0|^4.0",
+        "symfony/dependency-injection": "~2.8|~3.0|^4.0",
+        "symfony/templating": "~2.8|~3.0|^4.0",
         "michelf/php-markdown":     "~1.4"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "php":                      ">=5.3.9",
         "symfony/framework-bundle": "~2.3|~3.0|^4.0",
         "symfony/dependency-injection": "~2.3|~3.0|^4.0",
+        "symfony/templating": "~2.3|~3.0|^4.0",
         "michelf/php-markdown":     "~1.4"
     },
     "require-dev": {


### PR DESCRIPTION
I also add dependency for templating, because use [HelperInterface](https://github.com/KnpLabs/KnpMarkdownBundle/blob/master/Helper/MarkdownHelper.php#L6) to fix the tests. Tests fails due to PHP 5.3 and HHVM. I fix test on PHP 5.3 when use dist precise but for HHVM, phpunit 6.x not work.