### PR TITLE
Making the templating component an optional dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+1.7
+===
+
+* The MarkdownHelper Templating component integration (and corresponding
+  `templating.helper.markdown` services) are no longer added unless you
+  have the `symfony/templating` component installed.

--- a/DependencyInjection/KnpMarkdownExtension.php
+++ b/DependencyInjection/KnpMarkdownExtension.php
@@ -10,6 +10,7 @@ use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\Templating\EngineInterface;
 
 class KnpMarkdownExtension extends Extension
 {
@@ -29,7 +30,10 @@ class KnpMarkdownExtension extends Extension
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('parser.xml');
-        $loader->load('helper.xml');
+        // BC to support the PHP templates in the Templating component
+        if (interface_exists(EngineInterface::class)) {
+            $loader->load('helper.xml');
+        }
         $loader->load('twig.xml');
 
         if ('markdown.parser.sundown' == $config['parser']['service']) {

--- a/Helper/MarkdownHelper.php
+++ b/Helper/MarkdownHelper.php
@@ -5,6 +5,9 @@ namespace Knp\Bundle\MarkdownBundle\Helper;
 use Knp\Bundle\MarkdownBundle\Parser\ParserManager;
 use Symfony\Component\Templating\Helper\HelperInterface;
 
+/**
+ * @deprecated The MarkdownHelper was deprecated in 1.7 and will be removed in 2.0.
+ */
 class MarkdownHelper implements HelperInterface
 {
     private $parserManager;
@@ -27,6 +30,8 @@ class MarkdownHelper implements HelperInterface
      */
     public function transform($markdownText, $parserName = null)
     {
+        trigger_error('The MarkdownHelper was deprecated in 1.7 and will be removed in KnpMarkdownBundle 2.0.', E_USER_DEPRECATED);
+
         return $this->parserManager->transform($markdownText, $parserName);
     }
 

--- a/Tests/FeatureTest.php
+++ b/Tests/FeatureTest.php
@@ -749,31 +749,15 @@ That's some text with a footnote.[^1]
 [^1]: And that's the footnote.
 EOF;
 
-        $html = <<<EOF
-<p>That's some text with a footnote.<sup id="fnref:1"><a href="#fn:1" class="footnote-ref">1</a></sup></p>
-
-<div class="footnotes">
-<hr />
-<ol>
-
-<li id="fn:1">
-<p>And that's the footnote.&#160;<a href="#fnref:1" class="footnote-backref">&#8617;&#xFE0E;</a></p>
-</li>
-
-</ol>
-</div>
-
-EOF;
-
-        // newer versions of Michelf add an extra &#xFE0E; To make the tests
-        // pass against ALL versions, we just hack the &#xFE0E; into the
-        // expected string if it isn't there
         $actualHtml = $parser->transform($text);
-        if (strpos($actualHtml, '&#xFE0E;') === false) {
-            $actualHtml = str_replace('&#8617;', '&#8617;&#xFE0E;', $actualHtml);
-        }
 
-        $this->assertEquals($html, $actualHtml);
+        // asserting a few things instead of comparing full final HTML
+        // because a few minor things have changed over versions of Michelf
+        // With assertContains(), tests will pass across all versions
+        $this->assertContains('<p>That\'s some text with a footnote.<sup id="fnref:1"><a href="#fn:1"', $actualHtml);
+        $this->assertContains('<div class="footnotes"', $actualHtml);
+        $this->assertContains('<li id="fn:1"', $actualHtml);
+        $this->assertContains('<p>And that\'s the footnote.&#160;<a href="#fnref:1" class="footnote-backref"', $actualHtml);
     }
 
     /**

--- a/Tests/Parser/ParserManagerTest.php
+++ b/Tests/Parser/ParserManagerTest.php
@@ -24,10 +24,5 @@ class ParserManagerTest extends \PHPUnit_Framework_TestCase
 
         $actual = $parserManager->transform('*hi*', 'light');
         $this->assertEquals("<p><em>hi</em></p>\n", $actual, 'Specific parsers are registered');
-
-        /** @var MarkdownHelper $markdownHelper */
-        $markdownHelper = $container->get('templating.helper.markdown');
-        $actual = $markdownHelper->transform('*yo*');
-        $this->assertEquals("<p><em>yo</em></p>\n", $actual, 'The templating helper also works');
     }
 }

--- a/Tests/fixtures/app/TestKernel.php
+++ b/Tests/fixtures/app/TestKernel.php
@@ -5,6 +5,7 @@ namespace Knp\Bundle\MarkdownBundle\Tests\fixtures\app;
 use Knp\Bundle\MarkdownBundle\KnpMarkdownBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\Kernel;
@@ -27,7 +28,7 @@ class TestKernel extends Kernel
             ));
 
             // add a public alias so we can fetch for testing
-            $c->setAlias('markdown.parser.parser_manager.public', 'markdown.parser.parser_manager');
+            $c->setAlias('markdown.parser.parser_manager.public', new Alias('markdown.parser.parser_manager', true));
         });
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
         "php":                      ">=5.5.9",
         "symfony/framework-bundle": "~2.8|~3.0|^4.0",
         "symfony/dependency-injection": "~2.8|~3.0|^4.0",
-        "symfony/templating": "~2.8|~3.0|^4.0",
         "michelf/php-markdown":     "~1.4"
     },
     "require-dev": {
-        "phpunit/phpunit":          "~4.5"
+        "phpunit/phpunit":          "~4.5",
+        "symfony/templating": "~2.8|~3.0|^4.0"
     },
     "suggest": {
         "symfony/twig-bundle": "to use the Twig markdown filter",


### PR DESCRIPTION
It already basically was, but we were requiring it. This could be seen as a minor BC break, butthe service in question is only NOT registered if you don't have the `symfony/templating` component installed... and it's whole purpose in life is to integrate with that component.

Cheers!